### PR TITLE
add missing comment for `compression_level`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ system:
         name: ".wings"
 
   backups:
-    # what compression level to use? best_speed, good_speed, good_compression, best_compression
+    # what compression level to use? best_speed, good_speed, good_compression, best_compression (higher compression = more CPU usage, better compression)
     compression_level: best_speed
     # allow browsing backups via the web file manager
     mounting:


### PR DESCRIPTION
added a comment for `compression_level` in the README based on the available enum values 
https://github.com/calagopus-rs/wings/blob/516d32a067286cf942ad0fa1f894a2c92bdb65bd/application/src/io/compression/mod.rs