### PR TITLE
Support listening on unix sockets

### DIFF
--- a/application/src/commands/diagnostics.rs
+++ b/application/src/commands/diagnostics.rs
@@ -187,7 +187,7 @@ pub async fn diagnostics(
                     .trim_start_matches("http://"),
                 "{redacted}",
             )
-            .replace(&config.api.host.to_string(), "{redacted}")
+            .replace(&config.api.host, "{redacted}")
             .replace(&config.system.sftp.bind_address.to_string(), "{redacted}");
 
         if !config.api.ssl.cert.is_empty() {

--- a/application/src/config.rs
+++ b/application/src/config.rs
@@ -19,8 +19,8 @@ use utoipa::ToSchema;
 fn app_name() -> String {
     "Pterodactyl".to_string()
 }
-fn api_host() -> std::net::IpAddr {
-    std::net::IpAddr::from([0, 0, 0, 0])
+fn api_host() -> String {
+    "0.0.0.0".to_string()
 }
 fn api_port() -> u16 {
     8080
@@ -440,8 +440,7 @@ nestify::nest! {
         #[schema(inline)]
         pub api: #[derive(ToSchema, Deserialize, Serialize, DefaultFromSerde)] #[serde(default)] pub struct Api {
             #[serde(default = "api_host")]
-            #[schema(value_type = String)]
-            pub host: std::net::IpAddr,
+            pub host: String,
             #[serde(default = "api_port")]
             pub port: u16,
 

--- a/application/src/routes/api/update.rs
+++ b/application/src/routes/api/update.rs
@@ -17,8 +17,7 @@ mod post {
 
             #[schema(inline)]
             api: Option<#[derive(ToSchema, Deserialize)] pub struct ApiPayload {
-                #[schema(value_type = Option<String>)]
-                host: Option<std::net::IpAddr>,
+                host: Option<String>,
                 port: Option<u16>,
 
                 #[schema(inline)]


### PR DESCRIPTION
If `host` in the config fails to parse as an IP address it will trying to bind to a Unix socket. Tested with Caddy and cURL by doing

cURL: `curl --unix-socket /tmp/calagopus.sock http://localhost/`
Caddy: `caddy reverse-proxy --from :8080 --to unix//tmp/calagopus.sock`