### PR TITLE
Allow Container Root UID

### DIFF
--- a/application/src/config.rs
+++ b/application/src/config.rs
@@ -1481,15 +1481,9 @@ impl Config {
                     }
 
                     cfg.system.user.uid = **user;
-                    if cfg.system.user.rootless.container_uid == 0 {
-                        cfg.system.user.rootless.container_uid = cfg.system.user.uid;
-                    }
                 }
                 if let Some(group) = process.group_id() {
                     cfg.system.user.gid = *group;
-                    if cfg.system.user.rootless.container_gid == 0 {
-                        cfg.system.user.rootless.container_gid = cfg.system.user.gid;
-                    }
                 }
 
                 if cfg.system.user.uid == 0 || cfg.system.user.gid == 0 {


### PR DESCRIPTION
From testing my own Wing running rootless Podman I have found most newly created servers cannot run their egg's installation as they expect to be running as root. This is still achievable with rootless Podman but requires the UID & GID in the container to be zero.

To make this possible I have created a small PR to remove the automatic overwriting and modification of the `system.user.rootless.container_uid` and `system.user.rootless.container_gid` configuration variables. From testing with my own compiled wing on my own server this successfully allows the egg install scripts to work.

NOTE: Further PRs will be needed for updating the documentation.