### PR TITLE
Log crash activity with exit code and OOM metadata

### DIFF
--- a/application/src/server/activity.rs
+++ b/application/src/server/activity.rs
@@ -13,6 +13,9 @@ pub enum ActivityEvent {
     #[serde(rename = "server:power.kill")]
     PowerKill,
 
+    #[serde(rename = "server:crash.detected")]
+    CrashDetected,
+
     #[serde(rename = "server:console.command")]
     ConsoleCommand,
 

--- a/application/src/server/mod.rs
+++ b/application/src/server/mod.rs
@@ -465,8 +465,6 @@ impl Server {
                                     return;
                                 }
 
-                                // Log a crash activity so panels can surface crash
-                                // context (exit code, oom kill) to users.
                                 server.activity.log_activity(activity::Activity {
                                     event: activity::ActivityEvent::CrashDetected,
                                     user: None,

--- a/application/src/server/mod.rs
+++ b/application/src/server/mod.rs
@@ -465,6 +465,20 @@ impl Server {
                                     return;
                                 }
 
+                                // Log a crash activity so panels can surface crash
+                                // context (exit code, oom kill) to users.
+                                server.activity.log_activity(activity::Activity {
+                                    event: activity::ActivityEvent::CrashDetected,
+                                    user: None,
+                                    ip: None,
+                                    metadata: Some(json!({
+                                        "exit_code": exit_code,
+                                        "oom_killed": oom_killed,
+                                    })),
+                                    schedule: None,
+                                    timestamp: chrono::Utc::now(),
+                                });
+
                                 server.schedules.execute_crash_trigger().await;
 
                                 server.log_daemon_with_prelude("---------- Detected server process in a crashed state! ----------");


### PR DESCRIPTION
## Summary

When crash detection triggers, wings already knows the exit code and
whether the container was OOM-killed — but that context never leaves the
daemon. It is only printed to the server console, which is lost once the
container is removed (`delete_container_on_stop` defaults to true), so
there is no way for a panel to tell *that* a server crashed, let alone why.

This PR logs a `server:crash.detected` activity with `exit_code` and
`oom_killed` metadata at the moment wings itself decides a stop was a
crash. That makes crash context available to panels for things like crash
counters, alerting, or support tooling.

## Implementation notes

- The event fires only after the existing clean-exit gate, i.e. exactly
  when wings considers the stop a crash — the semantics of
  `system.crash_detection` (including `detect_clean_exit_as_crash`) are
  unchanged, and no new config is introduced.
- It is emitted right next to `execute_crash_trigger()`, before the
  restart throttle, so throttled crash loops are still each recorded.
- `log_activity` is non-blocking (`try_send` into the activity channel),
  so the restart flow is never delayed.
- No panel changes are required: the remote activity endpoint accepts
  event strings as-is, so the event lands in `server_activities`
  untouched. A frontend translation for `server:crash.detected` could be
  a small follow-up in the panel repo — happy to open that as well.

## Testing

- `cargo check --workspace` passes.
- Manually traced the crash path: the activity is only reachable through
  the same branch that prints "Detected server process in a crashed
  state!", so behaviour is 1:1 with the existing crash decision.

17 lines, no dependencies, no config changes.
