### PR TITLE
Add gamedig game status fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-rs"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beeb59e7e4c811ab37cc73680c798c7a5da77fc9989c62b09138e31ee740f735"
+dependencies = [
+ "crc32fast",
+ "tinyvec",
+]
+
+[[package]]
 name = "cap-primitives"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,7 +739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -1714,6 +1724,24 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "gamedig"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d451c96ec779b50a93ce6b67bfd25f4715d7cbfbc17dda590f24dabc62c3fb17"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bzip2-rs",
+ "crc32fast",
+ "encoding_rs",
+ "phf 0.13.1",
+ "serde",
+ "serde_json",
+ "ureq 2.12.1",
+ "url",
 ]
 
 [[package]]
@@ -3389,7 +3417,41 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3397,6 +3459,15 @@ name = "phf_shared"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -5427,6 +5498,24 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
@@ -5438,7 +5527,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -5681,6 +5770,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -6048,6 +6146,7 @@ dependencies = [
  "dialoguer",
  "flate2",
  "futures",
+ "gamedig",
  "gzp",
  "hex",
  "hickory-resolver",
@@ -6111,7 +6210,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "unrar",
- "ureq",
+ "ureq 3.3.0",
  "url",
  "utoipa",
  "utoipa-axum",

--- a/application/Cargo.toml
+++ b/application/Cargo.toml
@@ -100,6 +100,7 @@ ini-roundtrip = "0.2.1"
 itertools = "0.15.0"
 yrs = "0.27.2"
 croner = { version = "3.0.1", features = ["serde"] }
+gamedig = { version = "0.9.0", features = ["serde", "tls"] }
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 tikv-jemallocator = "0.6.0"

--- a/application/src/commands/migrate_disk_limiter.rs
+++ b/application/src/commands/migrate_disk_limiter.rs
@@ -132,6 +132,9 @@ impl crate::commands::CliCommand<MigrateDiskLimiterArgs> for MigrateDiskLimiterC
                             .expect("failed to initialize inotify manager"),
                     ),
                     mime_cache: moka::future::Cache::new(20480),
+                    gamedig_cache: moka::future::Cache::builder()
+                        .time_to_live(crate::gamedig::CACHE_TTL)
+                        .build(),
                 });
 
                 let mut migrated = 0;

--- a/application/src/gamedig/mod.rs
+++ b/application/src/gamedig/mod.rs
@@ -1,0 +1,199 @@
+use crate::server::{Server, state::ServerState};
+use compact_str::CompactString;
+use gamedig::{GAMES, Game, protocols::types::TimeoutSettings};
+use serde::Serialize;
+use std::{net::SocketAddr, time::Duration};
+use utoipa::ToSchema;
+
+pub const CACHE_TTL: Duration = Duration::from_secs(30);
+
+/// The response returned for a single server game query.
+#[derive(ToSchema, Serialize, Debug, Clone)]
+pub struct GameDigResponse {
+    /// Whether a `gamedig_*` egg feature is configured for this server.
+    pub enabled: bool,
+    /// The detected game identifier, if enabled.
+    pub game: Option<CompactString>,
+    /// Whether the game server responded to the query.
+    pub online: bool,
+    /// The amount of players currently connected.
+    pub players_online: Option<u32>,
+    /// The maximum amount of players that can connect.
+    pub players_maximum: Option<u32>,
+    /// The current map name, when provided by the game protocol.
+    pub map: Option<CompactString>,
+    /// The game version reported by the server, when provided.
+    pub version: Option<CompactString>,
+}
+
+impl GameDigResponse {
+    fn disabled() -> Self {
+        Self {
+            enabled: false,
+            game: None,
+            online: false,
+            players_online: None,
+            players_maximum: None,
+            map: None,
+            version: None,
+        }
+    }
+
+    fn offline(game: &str) -> Self {
+        Self {
+            enabled: true,
+            game: Some(game.into()),
+            online: false,
+            players_online: None,
+            players_maximum: None,
+            map: None,
+            version: None,
+        }
+    }
+}
+
+/// Maps an egg feature to the gamedig game identifier used to query it.
+const FEATURE_GAMES: &[(&str, &str)] = &[
+    ("gamedig_minecraft", "minecraft"),
+    ("gamedig_tf2", "teamfortress2"),
+    ("gamedig_csgo", "csgo"),
+    ("gamedig_css", "css"),
+    ("gamedig_zomboid", "projectzomboid"),
+];
+
+/// Looks through the egg features for a `gamedig_*` feature.
+fn detect_game(features: &[CompactString]) -> Option<&'static str> {
+    for feature in features {
+        for (name, game) in FEATURE_GAMES {
+            if feature == *name {
+                return Some(game);
+            }
+        }
+    }
+
+    None
+}
+
+fn perform_query(game: &Game, target: &SocketAddr, game_id: &'static str) -> GameDigResponse {
+    let timeout_settings = TimeoutSettings::new(
+        Some(Duration::from_secs(4)),
+        Some(Duration::from_secs(4)),
+        Some(Duration::from_secs(4)),
+        0,
+    );
+
+    let Ok(timeout_settings) = timeout_settings else {
+        return GameDigResponse::disabled();
+    };
+
+    match gamedig::games::query::query_with_timeout(
+        game,
+        &target.ip(),
+        Some(target.port()),
+        Some(timeout_settings),
+    ) {
+        Ok(response) => {
+            let data = response.as_json();
+            GameDigResponse {
+                enabled: true,
+                game: Some(game_id.into()),
+                online: true,
+                players_online: Some(data.players_online),
+                players_maximum: Some(data.players_maximum),
+                map: data.map.map(Into::into),
+                version: data.game_version.map(Into::into),
+            }
+        }
+        Err(err) => {
+            tracing::debug!(
+                target = %target,
+                game = %game_id,
+                "gamedig query failed: {err}"
+            );
+            GameDigResponse::offline(game_id)
+        }
+    }
+}
+
+async fn query_game_server(
+    game: Game,
+    target: SocketAddr,
+    game_id: &'static str,
+) -> GameDigResponse {
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        tokio::task::spawn_blocking(move || perform_query(&game, &target, game_id)),
+    )
+    .await
+    .map_or_else(
+        |_| {
+            tracing::debug!(
+                target = %target,
+                game = %game_id,
+                "gamedig query timed out"
+            );
+            GameDigResponse::offline(game_id)
+        },
+        |result| {
+            result.unwrap_or_else(|err| {
+                tracing::error!(
+                    target = %target,
+                    game = %game_id,
+                    "gamedig query task failed: {err}"
+                );
+                GameDigResponse::offline(game_id)
+            })
+        },
+    )
+}
+
+pub async fn query_server(server: &Server, state: &crate::routes::AppState) -> GameDigResponse {
+    let configuration = server.configuration.read().await;
+
+    let Some(game_id) = detect_game(&configuration.egg.features) else {
+        return GameDigResponse::disabled();
+    };
+
+    if server.state.get_state() != ServerState::Running {
+        return GameDigResponse::offline(game_id);
+    }
+
+    let Some(allocation_port) = configuration.allocations.default.as_ref().map(|d| d.port) else {
+        return GameDigResponse::offline(game_id);
+    };
+
+    drop(configuration);
+
+    let Some(game) = GAMES.get(game_id).cloned() else {
+        return GameDigResponse::offline(game_id);
+    };
+
+    let target = match state
+        .executor
+        .resolve_internal_target(server, allocation_port)
+        .await
+    {
+        Ok(Some(target)) => target,
+        Ok(None) => {
+            tracing::debug!(
+                server = %server.uuid,
+                game = %game_id,
+                "no internal target could be resolved for gamedig query"
+            );
+            return GameDigResponse::offline(game_id);
+        }
+        Err(err) => {
+            tracing::debug!(
+                server = %server.uuid,
+                game = %game_id,
+                "failed to resolve internal target for gamedig query: {err}"
+            );
+            return GameDigResponse::offline(game_id);
+        }
+    };
+
+    state
+        .gamedig_cache
+        .get_with(server.uuid, query_game_server(game, target, game_id))
+        .await
+}

--- a/application/src/main.rs
+++ b/application/src/main.rs
@@ -24,6 +24,7 @@ mod bins;
 mod commands;
 mod config;
 mod deserialize;
+mod gamedig;
 mod io;
 mod models;
 mod net;
@@ -471,6 +472,9 @@ async fn main_rt() {
                 .expect("failed to initialize inotify manager"),
         ),
         mime_cache: moka::future::Cache::new(20480),
+        gamedig_cache: moka::future::Cache::builder()
+            .time_to_live(crate::gamedig::CACHE_TTL)
+            .build(),
     });
 
     tokio::spawn({

--- a/application/src/routes/api/servers/_server_/gamedig.rs
+++ b/application/src/routes/api/servers/_server_/gamedig.rs
@@ -1,0 +1,30 @@
+use super::State;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+mod get {
+    use crate::{
+        response::{ApiResponse, ApiResponseResult},
+        routes::{GetState, api::servers::_server_::GetServer},
+    };
+
+    #[utoipa::path(get, path = "/", responses(
+        (status = OK, body = crate::gamedig::GameDigResponse),
+    ), params(
+        (
+            "server" = uuid::Uuid,
+            description = "The server uuid",
+            example = "123e4567-e89b-12d3-a456-426614174000",
+        ),
+    ))]
+    pub async fn route(state: GetState, server: GetServer) -> ApiResponseResult {
+        let response = crate::gamedig::query_server(&server, &state).await;
+
+        ApiResponse::new_serialized(response).ok()
+    }
+}
+
+pub fn router(state: &State) -> OpenApiRouter<State> {
+    OpenApiRouter::new()
+        .routes(routes!(get::route))
+        .with_state(state.clone())
+}

--- a/application/src/routes/api/servers/_server_/mod.rs
+++ b/application/src/routes/api/servers/_server_/mod.rs
@@ -12,6 +12,7 @@ use utoipa_axum::{router::OpenApiRouter, routes};
 mod backup;
 mod commands;
 mod files;
+mod gamedig;
 mod install;
 mod logs;
 mod power;
@@ -125,6 +126,7 @@ pub fn router(state: &State) -> OpenApiRouter<State> {
         .nest("/files", files::router(state))
         .nest("/backup", backup::router(state))
         .nest("/schedules", schedules::router(state))
+        .nest("/gamedig", gamedig::router(state))
         .routes(routes!(get::route))
         .routes(routes!(delete::route))
         .route_layer(axum::middleware::from_fn_with_state(state.clone(), auth))

--- a/application/src/routes/mod.rs
+++ b/application/src/routes/mod.rs
@@ -144,6 +144,7 @@ pub struct AppState {
     pub backup_manager: Arc<crate::server::backup::manager::BackupManager>,
     pub inotify_manager: Arc<crate::server::filesystem::inotify::InotifyManager>,
     pub mime_cache: moka::future::Cache<MimeCacheKey, MimeCacheValue>,
+    pub gamedig_cache: moka::future::Cache<uuid::Uuid, crate::gamedig::GameDigResponse>,
 }
 
 impl AppState {
@@ -163,6 +164,9 @@ impl AppState {
                     .expect("Creating inotify manager failed"),
             ),
             mime_cache: moka::future::Cache::builder().build(),
+            gamedig_cache: moka::future::Cache::builder()
+                .time_to_live(crate::gamedig::CACHE_TTL)
+                .build(),
         })
     }
 }

--- a/application/src/server/configuration/mod.rs
+++ b/application/src/server/configuration/mod.rs
@@ -184,6 +184,8 @@ nestify::nest! {
             pub id: uuid::Uuid,
             #[serde(default, deserialize_with = "crate::deserialize::deserialize_defaultable")]
             pub file_denylist: Vec<compact_str::CompactString>,
+            #[serde(default)]
+            pub features: Vec<compact_str::CompactString>,
         },
 
         #[schema(inline)]
@@ -266,6 +268,7 @@ impl ServerConfiguration {
             egg: ServerConfigurationEgg {
                 id: uuid::Uuid::new_v4(),
                 file_denylist: Vec::new(),
+                features: Vec::new(),
             },
             container: ServerConfigurationContainer {
                 image: "example/image:latest".into(),

--- a/compose.yml
+++ b/compose.yml
@@ -26,6 +26,4 @@ services:
       - "/tmp/calagopus-wings/:/tmp/calagopus-wings/"
       # do not mount directly to /etc/ssl/certs (right side), this will cause certificate issues within the container
       - "/etc/ssl/certs/wings/:/etc/ssl/certs/wings/:ro"
-    ports:
-      - 8080:8080
-      - 2022:2022
+    network_mode: host


### PR DESCRIPTION
Adds player count fetching for Minecraft, TF2, CSGO, CS Source and Zomboid. In order to work this requires an egg feature to be set (for example `gamedig_minecraft`).

I have also changed the compose.yml file to have the network-mode set to host, which is required for the daemon to reach the game servers. As an alternative it should be possible to attach the interface created for servers, however it's not worth it imo.